### PR TITLE
Add proc macros to bootstrap runtime for main and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           toolchain: stable
           override: true
     - name: Build code
-      run: cargo build
+      run: cargo build --workspace --examples
   test:
     needs: [build]
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add proc macros to bootstrap runtime for main and test
+
 ### Changed
 - Stop runtime in phases to avoid unnecessary thread panic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop runtime in phases to avoid unnecessary thread panic
 
 ## [0.1.2] - 2022-03-26
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ lazy_static = "1.4.0"
 errno = "0.2.8"
 static_assertions = "1.1.0"
 ignore-result = "0.2.0"
+stuck-macros = { version ="0.1.1", path = "macros" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.0"
 test-case = "2.0.2"
+
+[workspace]
+members = ["macros"]

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ Stuck is a multi-threading scheduled task facility building on cooperative stack
 
 ## Examples
 ```rust
-use stuck::runtime::Runtime;
 use stuck::{coroutine, task};
 
+#[stuck::main]
 fn main() {
-    let runtime = Runtime::new();
-    let twenty = runtime.spawn(|| {
+    let twenty = task::spawn(|| {
         let five_coroutine = coroutine::spawn(|| 5);
 
         let (suspension, resumption) = coroutine::suspension::<i32>();

--- a/examples/twenty.rs
+++ b/examples/twenty.rs
@@ -1,0 +1,19 @@
+use stuck::{coroutine, task};
+
+#[stuck::main]
+fn main() {
+    let twenty = task::spawn(|| {
+        let five_coroutine = coroutine::spawn(|| 5);
+
+        let (suspension, resumption) = coroutine::suspension::<i32>();
+        coroutine::spawn(move || resumption.resume(5));
+
+        let five_task = task::spawn(|| 5);
+
+        let (session, waker) = task::session::<i32>();
+        task::spawn(move || waker.wake(5));
+
+        session.wait() + suspension.suspend() + five_coroutine.join().unwrap() + five_task.join().unwrap()
+    });
+    println!("twenty.join().unwrap(): {}", twenty.join().unwrap());
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "stuck-macros"
+version = "0.1.1"
+edition = "2021"
+authors = ["Kezhu Wang <kezhuw@gmail.com>"]
+description = "Macros to bootstrap stuck"
+homepage = "https://github.com/kezhuw/stuck-macros"
+repository = "https://github.com/kezhuw/stuck-macros"
+documentation = "https://docs.rs/stuck-macros"
+license = "MIT"
+categories = ["Concurrency"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = {version ="1.0", features=["full"]}
+quote = "1.0"
+proc-macro2 = "1.0.37"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,113 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+
+#[derive(Default)]
+struct Configuration {
+    parallelism: Option<usize>,
+}
+
+impl Configuration {
+    fn set_parallelism(&mut self, span: Span, lit: syn::Lit) -> Result<(), syn::Error> {
+        if self.parallelism.is_some() {
+            return Err(syn::Error::new(span, "parallelism already set"));
+        }
+        if let syn::Lit::Int(lit) = lit {
+            let parallelism = lit.base10_parse::<usize>()?;
+            if parallelism > 0 {
+                self.parallelism = Some(parallelism);
+                return Ok(());
+            }
+        }
+        Err(syn::Error::new(span, "parallelism should be positive integer"))
+    }
+}
+
+fn parse_config(args: syn::AttributeArgs) -> Result<Configuration, syn::Error> {
+    let mut config = Configuration::default();
+    for arg in args.into_iter() {
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) => {
+                let name = name_value
+                    .path
+                    .get_ident()
+                    .ok_or_else(|| syn::Error::new_spanned(&name_value, "invalid attribute name"))?
+                    .to_string();
+                match name.as_str() {
+                    "parallelism" => config.set_parallelism(name_value.lit.span(), name_value.lit)?,
+                    _ => return Err(syn::Error::new_spanned(&name_value, "unknown attribute name")),
+                }
+            },
+            _ => return Err(syn::Error::new_spanned(arg, "unknown attribute")),
+        }
+    }
+    Ok(config)
+}
+
+fn generate(is_test: bool, attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = syn::parse_macro_input!(attr as syn::AttributeArgs);
+    let config = parse_config(args).unwrap();
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let inputs = &input.sig.inputs;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+
+    let macro_name = if is_test { "#[stuck::test]" } else { "#[stuck::main]" };
+
+    if input.sig.asyncness.is_some() {
+        let err =
+            syn::Error::new_spanned(input, format!("only synchronous function can be tagged with {}", macro_name));
+        return TokenStream::from(err.into_compile_error());
+    }
+
+    if !is_test && name != "main" {
+        let err = syn::Error::new_spanned(name, "only the main function can be tagged with #[stuck::main]");
+        return TokenStream::from(err.into_compile_error());
+    }
+
+    let header = if is_test {
+        quote! {
+            #[::core::prelude::v1::test]
+        }
+    } else {
+        quote! {}
+    };
+
+    let parallelism = config.parallelism.unwrap_or(0);
+    let result = quote! {
+        #header
+        #vis fn #name() #ret {
+            #(#attrs)*
+            fn entry(#inputs) #ret {
+                #body
+            }
+
+            let mut builder = stuck::runtime::Builder::default();
+            if #parallelism != 0 {
+                builder.parallelism(#parallelism);
+            }
+            let runtime = builder.build();
+            let task = runtime.spawn(entry);
+            task.join().unwrap()
+        }
+    };
+
+    result.into()
+}
+
+#[cfg(not(test))]
+#[proc_macro_attribute]
+pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
+    generate(false, attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    generate(true, attr, item)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_doctest_main)]
+
 //! # Multi-threading task facility building on cooperative stackful coroutine
 //! `stuck` provides a multi-threading runtime to serve lightweight concurrent tasks where you can
 //! use [coroutine::suspension] to cooperatively resume suspending coroutines.
@@ -19,24 +21,25 @@
 //!
 //! ## Example
 //! ```rust
-//! use stuck::runtime::Runtime;
 //! use stuck::{coroutine, task};
 //!
-//! let runtime = Runtime::new();
-//! let twenty = runtime.spawn(|| {
-//!     let five_coroutine = coroutine::spawn(|| 5);
+//! #[stuck::main]
+//! fn main() {
+//!     let twenty = task::spawn(|| {
+//!         let five_coroutine = coroutine::spawn(|| 5);
 //!
-//!     let (suspension, resumption) = coroutine::suspension::<i32>();
-//!     coroutine::spawn(move || resumption.resume(5));
+//!         let (suspension, resumption) = coroutine::suspension::<i32>();
+//!         coroutine::spawn(move || resumption.resume(5));
 //!
-//!     let five_task = task::spawn(|| 5);
+//!         let five_task = task::spawn(|| 5);
 //!
-//!     let (session, waker) = task::session::<i32>();
-//!     task::spawn(move || waker.wake(5));
+//!         let (session, waker) = task::session::<i32>();
+//!         task::spawn(move || waker.wake(5));
 //!
-//!     session.wait() + suspension.suspend() + five_coroutine.join().unwrap() + five_task.join().unwrap()
-//! });
-//! assert_eq!(20, twenty.join().unwrap());
+//!         session.wait() + suspension.suspend() + five_coroutine.join().unwrap() + five_task.join().unwrap()
+//!     });
+//!     println!("twenty.join().unwrap(): {}", twenty.join().unwrap());
+//! }
 //! ```
 
 pub mod coroutine;
@@ -47,3 +50,6 @@ pub mod time;
 
 pub use coroutine::stack::StackSize;
 pub use error::JoinError;
+#[cfg(not(test))]
+pub use stuck_macros::main;
+pub use stuck_macros::test;

--- a/tests/stuck.rs
+++ b/tests/stuck.rs
@@ -86,7 +86,7 @@ fn test_coroutine_suspension_no_wakeup() {
 }
 
 #[test]
-fn test_example() {
+fn test_twenty() {
     let runtime = Runtime::new();
     let twenty = runtime.spawn(|| {
         let five_coroutine = coroutine::spawn(|| 5);


### PR DESCRIPTION
- Stop runtime in phases to avoid unnecessary thread panic
- Add proc macros to bootstrap runtime for main and test
