### PR TITLE
Support package name customization in #[stuck::main] and #[stuck::test]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support package name customization in #[stuck::main] and #[stuck::test]
+
 ## [0.1.5] - 2022-04-09
 ### Added
 - `Sender::try_send` to send without blocking current execution.

--- a/src/coroutine/mod.rs
+++ b/src/coroutine/mod.rs
@@ -297,13 +297,11 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    use crate::coroutine;
-    use crate::runtime::Runtime;
+    use crate::{coroutine, task};
 
-    #[test]
+    #[crate::test(package = "crate")]
     fn yield_now() {
-        let runtime = Runtime::new();
-        let five = runtime.spawn(|| {
+        let five = task::spawn(|| {
             let value = Rc::new(Cell::new(0));
             let shared_value = value.clone();
             coroutine::spawn(move || {

--- a/src/task.rs
+++ b/src/task.rs
@@ -596,13 +596,11 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    use crate::runtime::Builder;
     use crate::{coroutine, task};
 
-    #[test]
+    #[crate::test(package = "crate", parallelism = 1)]
     fn yield_now() {
-        let runtime = Builder::default().parallelism(1).build();
-        let five = runtime.spawn(|| {
+        let five = task::spawn(|| {
             let shared_value = Arc::new(Mutex::new(0));
             let shared_task_value = shared_value.clone();
             let shared_coroutine_value = shared_value.clone();


### PR DESCRIPTION
This enables `#[crate::test(package = "crate")]` in unit tests.
