### PR TITLE
Rename crate name customization option to 'crate'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support package name customization in #[stuck::main] and #[stuck::test]
+- Support crate name customization in #[stuck::main] and #[stuck::test]
 
 ## [0.1.5] - 2022-04-09
 ### Added

--- a/src/coroutine/mod.rs
+++ b/src/coroutine/mod.rs
@@ -299,7 +299,7 @@ mod tests {
 
     use crate::{coroutine, task};
 
-    #[crate::test(package = "crate")]
+    #[crate::test(crate = "crate")]
     fn yield_now() {
         let five = task::spawn(|| {
             let value = Rc::new(Cell::new(0));

--- a/src/task.rs
+++ b/src/task.rs
@@ -598,7 +598,7 @@ mod tests {
 
     use crate::{coroutine, task};
 
-    #[crate::test(package = "crate", parallelism = 1)]
+    #[crate::test(crate = "crate", parallelism = 1)]
     fn yield_now() {
         let five = task::spawn(|| {
             let shared_value = Arc::new(Mutex::new(0));


### PR DESCRIPTION
'package' is a project concept, while 'crate' means artifact. Basically,
all we imported are crates, but they are organized as packages.

Sees tokio-rs/tokio#4613
Sees https://github.com/rust-lang/book/blob/765318b844569a642ceef7bf1adab9639cbf6af3/src/ch07-01-packages-and-crates.md
