### PR TITLE
Refactor session/suspension implementations and semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support crate name customization in #[stuck::main] and #[stuck::test]
 
+### Changed
+- Refactor session/suspension implementations and semantics
+
 ## [0.1.5] - 2022-04-09
 ### Added
 - `Sender::try_send` to send without blocking current execution.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,51 +1,68 @@
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::fmt;
 
 use static_assertions::assert_impl_all;
 
-pub(crate) type PanicError = Box<dyn Any + Send + 'static>;
+pub(crate) enum PanicError {
+    Static(&'static str),
+    Unwind(Box<dyn Any + Send + 'static>),
+}
+
+impl PanicError {
+    fn into_boxed(self) -> Box<dyn Any + Send + 'static> {
+        match self {
+            PanicError::Unwind(boxed) => boxed,
+            PanicError::Static(str) => Box::new(str),
+        }
+    }
+
+    fn as_str(&self) -> Result<&str, TypeId> {
+        match self {
+            PanicError::Static(s) => Ok(s),
+            PanicError::Unwind(boxed) => {
+                let panicked = boxed.as_ref();
+                if let Some(s) = panicked.downcast_ref::<&str>() {
+                    Ok(s)
+                } else if let Some(s) = panicked.downcast_ref::<String>() {
+                    Ok(s.as_str())
+                } else {
+                    Err(panicked.type_id())
+                }
+            },
+        }
+    }
+}
 
 /// Wraps panic as [std::error::Error].
 pub struct JoinError {
-    panicked: Box<dyn Any + Send + 'static>,
+    err: PanicError,
 }
 
 assert_impl_all!(JoinError: Send);
 
 impl JoinError {
-    fn as_str(&self) -> Option<&str> {
-        let panicked = self.panicked.as_ref();
-        if let Some(s) = panicked.downcast_ref::<&str>() {
-            Some(s)
-        } else if let Some(s) = panicked.downcast_ref::<String>() {
-            Some(s.as_str())
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn new(err: Box<dyn Any + Send + 'static>) -> Self {
-        JoinError { panicked: err }
+    pub(crate) fn new(err: PanicError) -> Self {
+        JoinError { err }
     }
 
     /// Converts this error to panicked object.
     pub fn into_panic(self) -> Box<dyn Any + Send + 'static> {
-        self.panicked
+        self.err.into_boxed()
     }
 }
 
 impl fmt::Debug for JoinError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.as_str() {
-            None => write!(f, "JoinError::Panic({:?})", self.panicked.as_ref().type_id()),
-            Some(s) => write!(f, "JoinError::Panic({:?})", s),
+        match self.err.as_str() {
+            Ok(s) => write!(f, "JoinError::Panic({})", s),
+            Err(type_id) => write!(f, "JoinError::Panic({:?})", type_id),
         }
     }
 }
 
 impl fmt::Display for JoinError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "panic({:?})", self.as_str().unwrap_or(".."))
+        write!(f, "panic({})", self.err.as_str().unwrap_or(".."))
     }
 }
 


### PR DESCRIPTION
* Implements `Yielding` for `Session` and `Suspension` and store it in
  task during suspension for interruption in task abortion.
* Implements `Drop` for `Session` and `Suspension` to cancel themselves
  if not suspended.
* Implements `Clone` for `SessionWaker` and `Resumption` to wait for
  multiple peers simultaneously.
* Introduces `send` for `SessionWaker` and `Resumption` to let waker
  know wakeup result.
* Guarantee that no resource linger after `Session::wait` and
  `Suspension::suspend`.
